### PR TITLE
Alt shift backtick

### DIFF
--- a/AltBacktick.cpp
+++ b/AltBacktick.cpp
@@ -16,11 +16,20 @@ int StartBackgroundApp() {
 
     MSG msg;
     UINT keyCode = MapVirtualKey(BACKTICK_SCAN_CODE, MAPVK_VSC_TO_VK);
-    if (!RegisterHotKey(NULL, NULL, MOD_ALT, keyCode)) {
+    if (!RegisterHotKey(NULL, 1, MOD_ALT, keyCode)) {
         DWORD lastError = GetLastError();
         if (lastError == ERROR_HOTKEY_ALREADY_REGISTERED) {
             MessageBox(
                 NULL, L"Failed to register the ALT+~ hotkey.\nMake sure no other application is already binding to it.",
+                L"Failed to register hotkey", MB_ICONEXCLAMATION);
+            return 0;
+        }
+    }
+    if (!RegisterHotKey(NULL, 2, MOD_ALT | MOD_SHIFT, keyCode)){
+        DWORD lastError = GetLastError();
+        if (lastError == ERROR_HOTKEY_ALREADY_REGISTERED) {
+            MessageBox(
+                NULL, L"Failed to register the ALT+SHIFT+~ hotkey.\nMake sure no other application is already binding to it.",
                 L"Failed to register hotkey", MB_ICONEXCLAMATION);
             return 0;
         }

--- a/AltBacktick.cpp
+++ b/AltBacktick.cpp
@@ -36,15 +36,18 @@ int StartBackgroundApp() {
     }
 
     WindowFinder windowFinder;
-    HWND lastWindow = nullptr;
+
     while (GetMessage(&msg, nullptr, 0, 0)) {
         if (msg.message == WM_HOTKEY) {
             std::vector<HWND> windows = windowFinder.FindCurrentProcessWindows();
             HWND windowToFocus = nullptr;
-            for (const HWND &window : windows) {
-                if (window != lastWindow || windows.size() == 1) {
-                    windowToFocus = window;
-                }
+            if (windows.size() < 1) {
+                continue; 
+            }
+            if (msg.lParam & MOD_SHIFT){
+                windowToFocus = windows[0];
+            } else {
+                windowToFocus = *--windows.end();
             }
 
             if (windowToFocus != nullptr) {
@@ -54,7 +57,6 @@ int StartBackgroundApp() {
                     ShowWindow(windowToFocus, SW_RESTORE);
                 }
                 SetForegroundWindow(windowToFocus);
-                lastWindow = windowToFocus;
             }
         }
     }


### PR DESCRIPTION
This adds a second hotkey "ALT+SHIFT+backtick" that navigates to back to the previous highest z-order window.  This kind of adds what was being requested in https://github.com/akiver/AltBacktick/issues/2, though not quite.  

This also refactors things a bit to remove a for_each loop that was confusing me.