### PR TITLE
Cycle through windows in Most Recently Used order

### DIFF
--- a/AltBacktick.cpp
+++ b/AltBacktick.cpp
@@ -74,6 +74,15 @@ int StartBackgroundApp() {
             else
                 offset = 0;
             std::vector<HWND> windows = windowFinder.FindCurrentProcessWindows();
+
+            // Current window should be first if the user clicked or alt-tabbed to another window.
+            HWND curWindow = GetForegroundWindow();
+            std::vector<HWND>::iterator it = std::find(mru.begin(), mru.end(), curWindow);
+            if (it != mru.end()) {
+                mru.erase(it);
+            }
+            mru.insert(mru.begin(), curWindow);
+
             HWND windowToFocus = nullptr;
             /*for (std::vector<HWND>::iterator mruIt = mru.begin(); mruIt != mru.end();) {
                 std::vector<HWND>::iterator wIt = std::find(windows.begin(), windows.end(), *mruIt);

--- a/WindowFinder.h
+++ b/WindowFinder.h
@@ -15,3 +15,5 @@ class WindowFinder {
   private:
     IVirtualDesktopManager *desktopManager; // Win10 ++ only.
 };
+
+std::wstring GetProcessNameFromProcessId(const DWORD processId);


### PR DESCRIPTION
Implements #2. This pull request cycles through windows in most recently used order using a hash table of Process Name to MRU list (actually a `vector`) and uses a Low-Level Keyboard Hook to catch Alt key events. There is another map of Process Name to current position in the list. I tried to make the code smart enough to handle the user hitting Alt-Tab or clicking causing the active window to change by putting the currently focused window first in the list.

I had to declare __GetProcessNameFromProcessId()__ in _WindowFinder.h_ in order to use it from _AltBacktick.cpp_.